### PR TITLE
Greeting Card Now Displays Only Once Per Session

### DIFF
--- a/Frontend/script.js
+++ b/Frontend/script.js
@@ -206,3 +206,18 @@ document.addEventListener("DOMContentLoaded", function () {
   typeEffect();
 });
 
+document.addEventListener("DOMContentLoaded", function () {
+  const overlay = document.getElementById("overlay");
+
+  // Check if greeting has already been shown in this session
+  if (!sessionStorage.getItem("greetingShown")) {
+    overlay.style.display = "flex"; // Show greeting card
+    sessionStorage.setItem("greetingShown", "true"); // Mark as shown
+  } else {
+    overlay.style.display = "none"; // Hide greeting card
+  }
+
+  document.querySelector(".close-btn").addEventListener("click", function () {
+    overlay.style.display = "none";
+  });
+});


### PR DESCRIPTION
Fixes: #46 

Description:
. The greeting card will now appear only once when the user first opens the site.
. Navigating between pages or reloading the site will not trigger the greeting again in the same session.
. Used sessionStorage to ensure that the greeting is shown only once per session.
. Once the browser tab is closed, the greeting will reset and show again in a new session.

 * Tested and Working:
 . Greeting appears on the first visit.
 . Does not appear again when navigating between pages.
 . Appears again only when the user closes and reopens the tab.

After Implementation:


Uploading Coding Club - Personal - Microsoft_ Edge 2025-02-15 16-58-28.mp4…









