### PR TITLE
Synchronized the colour of the sections according to the dark theme

### DIFF
--- a/Frontend/event.css
+++ b/Frontend/event.css
@@ -112,6 +112,11 @@ body {
 .add-event-btn:hover {
     background-color: #218838;
 }
+.dark-mode .hackathon-card{
+    background: #1e1e1e;
+    border: 1px solid black;
+    box-shadow: (4px 8px 15px rgba(255,255,255,0.1));
+}
 
 /* Event Form */
 .event-form {

--- a/Frontend/style.css
+++ b/Frontend/style.css
@@ -34,6 +34,31 @@ body {
     box-shadow: 0px 4px 15px rgba(255, 255, 255, 0.1);
 }
 
+.dark-mode #events{
+    background: #1e1e1e;
+    column-rule: #ffffff;
+    box-shadow: (0 4px 15px rgba(255,255,255,0.1));
+}
+.dark-mode #projects{
+    background: #1e1e1e;
+    column-rule: #ffffff;
+    box-shadow: (0 4px 15px rgba(255,255,255,0.1));
+}
+.dark-mode #about{
+    background: #1e1e1e;
+    column-rule: #ffffff;
+    box-shadow: (0 4px 15px rgba(255,255,255,0.1));
+}
+.dark-mode #contact{
+    background: #1e1e1e;
+    column-rule: #ffffff;
+    box-shadow: (0 4px 15px rgba(255,255,255,0.1));
+}
+.dark-mode .project-card{
+    background: #1e1e1e;
+    box-shadow: (0 4px 15px rgba(255,255,255,0.1));
+     border: 1px solid black;
+}
 /* Dark mode for form elements */
 .dark-mode form input,
 .dark-mode form textarea {


### PR DESCRIPTION
Fixes: #52 
 I have changed the events,about,contact and project sections according to the dark theme making it easier for the users to interact with the website.
 Previously:
![Screenshot 2025-02-16 140621](https://github.com/user-attachments/assets/f5b2a228-ed12-43d6-9151-23d5a6f1e4d2)
Now:

https://github.com/user-attachments/assets/ba95a051-1a68-4b56-afec-6eba36008389

Kindly merge it @ak-0283 
Thank You